### PR TITLE
Fixed Command Injection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ const dig = function dig(args = [], options = {}) {
   const raw = (options.raw === true) ? options.raw : args.includes('+short');
   const digCMD = options.dig || 'dig';
   return new Promise((resolve, reject) => {
-    const process = child.spawn(digCMD, args);
+    const process = child.execFile(digCMD, args.split(' '));
     let shellOutput = '';
 
     process.stdout.on('data', (chunk) => {


### PR DESCRIPTION
:gear: **Fix:**

The mitigation is implemented by using `execFile()` instead of `exec()` which takes input as an array preventing the ability to achieve a Command Injection Vulnerability as it escapes concatenated shell commands by default.